### PR TITLE
Newscript

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -41,7 +41,11 @@ jobs:
         conda info
     - name: Create conda environment
       run: |
-        conda create -y -q -n env python=${{ matrix.python-version }} numpy nose
+        conda create -y -q -n env python=${{ matrix.python-version }} numpy
+    - name: Install pynose # nose becomes deprecated for Python 3.12
+      run: |
+        source activate env
+        pip install pynose
     - name: Install package
       run: |
         source activate env
@@ -55,7 +59,7 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. 
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with nose
+    - name: Test with pynose
       run: |
         source activate env
         nosetests -v --exe tests

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.8, 3.9, '3.10', 3.11]
+        python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -7,9 +7,9 @@ name: build
 
 on:
   push:
-    branches: [ master, actions ]
+    branches: [ main, actions ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/DESItests/example_alphabetical.csv
+++ b/DESItests/example_alphabetical.csv
@@ -1,0 +1,245 @@
+Lastname,Firstname,Authorname,JoinedAsBuilder,Affiliation,ORCID
+Adame,Adrián Gutiérrez,A.~G.~Adame,False,"Instituto de F\'{\i}sica Te\'{o}rica (IFT) UAM/CSIC, Universidad Aut\'{o}noma de Madrid, Cantoblanco, E-28049, Madrid, Spain",
+Aguilar,Jessica Nicole,J.~Aguilar,True,"Lawrence Berkeley National Laboratory, 1 Cyclotron Road, Berkeley, CA 94720, USA",
+Ahlen,Steven,S.~Ahlen,True,"Physics Dept., Boston University, 590 Commonwealth Avenue, Boston, MA 02215, USA",0000-0001-6098-7247
+Alam,Shadab,S.~Alam,False,"Tata Institute of Fundamental Research, Homi Bhabha Road, Mumbai 400005, India",0000-0002-3757-6359
+Alexander,David,D.~M.~Alexander,False,"Centre for Extragalactic Astronomy, Department of Physics, Durham University, South Road, Durham, DH1 3LE, UK",0000-0002-5896-6313
+Alexander,David,D.~M.~Alexander,False,"Institute for Computational Cosmology, Department of Physics, Durham University, South Road, Durham DH1 3LE, UK",0000-0002-5896-6313
+Alvarez,Marcelo,M.~Alvarez,True,"Lawrence Berkeley National Laboratory, 1 Cyclotron Road, Berkeley, CA 94720, USA",
+Alves,Otávio,O.~Alves,False,"University of Michigan, Ann Arbor, MI 48109, USA",
+Anand,Abhijeet,A.~Anand,False,"Lawrence Berkeley National Laboratory, 1 Cyclotron Road, Berkeley, CA 94720, USA",0000-0003-2923-1585
+Andrade,Uendert,U.~Dos Santos Andrade,False,"University of Michigan, Ann Arbor, MI 48109, USA",
+Armengaud,Eric,E.~Armengaud,False,"IRFU, CEA, Universit\'{e} Paris-Saclay, F-91191 Gif-sur-Yvette, France",0000-0001-7600-5148
+Avila,Santiago,S.~Avila,False,"Institut de F\'{i}sica d’Altes Energies (IFAE), The Barcelona Institute of Science and Technology, Campus UAB, 08193 Bellaterra Barcelona, Spain",0000-0001-5043-3662
+Aviles,Alejandro,A.~Aviles,False,"Instituto de Ciencias F\'{\i}sicas, Universidad Aut\'onoma de M\'exico, Cuernavaca, Morelos, 62210, M\'exico",0000-0001-5998-3986
+Awan,Humna,H.~Awan,False,"University of Michigan, Ann Arbor, MI 48109, USA",
+Bahr-Kalus,Benedict,B.~Bahr-Kalus,False,"Universit\’e Claude Bernard Lyon 1, CNRS/IN2P3, IP2I, Lyon, France",0000-0002-4578-4019
+Bailey,Stephen,S.~Bailey,True,"Lawrence Berkeley National Laboratory, 1 Cyclotron Road, Berkeley, CA 94720, USA",0000-0003-4162-6619
+Bault,Abigail,A.~Bault,True,"Department of Physics and Astronomy, University of California, Irvine, 92697, USA",0000-0002-9964-1005
+Bautista,Julian,J.~Bautista,False,"Aix Marseille Univ, CNRS/IN2P3, CPPM, Marseille, France",
+Behera,Jayashree,J.~Behera,False,"Department of Physics, Kansas State University, 116 Cardwell Hall, Manhattan, KS 66506, USA",
+BenZvi,Segev,S.~BenZvi,True,"Department of Physics \& Astronomy, University of Rochester, 206 Bausch and Lomb Hall, P.O. Box 270171, Rochester, NY 14627-0171, USA",0000-0001-5537-4710
+Beutler,Florian,F.~Beutler,False,"Institute for Astronomy, University of Edinburgh, Royal Observatory, Blackford Hill, Edinburgh EH9 3HJ, UK",0000-0003-0467-5438
+Bianchi,Davide,D.~Bianchi,False,"Dipartimento di Fisica ``Aldo Pontremoli'', Universit\`a degli Studi di Milano, Via Celoria 16, I-20133 Milano, Italy",0000-0001-9712-0006
+Blake,Chris,C.~Blake,False,"Centre for Astrophysics \& Supercomputing, Swinburne University of Technology, P.O. Box 218, Hawthorn, VIC 3122, Australia",0000-0002-5423-5919
+Blum,Robert,R.~Blum,True,"NSF's NOIRLab, 950 N. Cherry Ave., Tucson, AZ 85719, USA",0000-0002-8622-4237
+Brieden,Samuel,S.~Brieden,False,"Institute for Astronomy, University of Edinburgh, Royal Observatory, Blackford Hill, Edinburgh EH9 3HJ, UK",0000-0003-3896-9215
+Brodzeller,Allyson,A.~Brodzeller,False,"Department of Physics and Astronomy, The University of Utah, 115 South 1400 East, Salt Lake City, UT 84112, USA",0000-0002-8934-0954
+Brooks,David,D.~Brooks,True,"Department of Physics \& Astronomy, University College London, Gower Street, London, WC1E 6BT, UK",
+Brown,Zachery,Z.~Brown,False,"Department of Physics \& Astronomy, University of Rochester, 206 Bausch and Lomb Hall, P.O. Box 270171, Rochester, NY 14627-0171, USA",
+Buckley-Geer,Elizabeth,E.~Buckley-Geer,True,"Department of Astronomy and Astrophysics, University of Chicago, 5640 South Ellis Avenue, Chicago, IL 60637, USA",
+Buckley-Geer,Elizabeth,E.~Buckley-Geer,True,"Fermi National Accelerator Laboratory, PO Box 500, Batavia, IL 60510, USA",
+Burtin,Etienne,E.~Burtin,False,"IRFU, CEA, Universit\'{e} Paris-Saclay, F-91191 Gif-sur-Yvette, France",
+Calderon,Rodrigo,R.~Calderon,False,"Korea Astronomy and Space Science Institute, 776, Daedeokdae-ro, Yuseong-gu, Daejeon 34055, Republic of Korea",
+Canning,Rebecca,R.~Canning,False,"Institute of Cosmology and Gravitation, University of Portsmouth, Dennis Sciama Building, Portsmouth, PO1 3FX, UK",
+Carnero Rosell,Aurelio,A.~Carnero Rosell,False,"Departamento de Astrof\'{\i}sica, Universidad de La Laguna (ULL), E-38206, La Laguna, Tenerife, Spain",0000-0003-3044-5150
+Carnero Rosell,Aurelio,A.~Carnero Rosell,False,"Instituto de Astrof\'{i}sica de Canarias, C/ Vía L\'{a}ctea, s/n, E-38205 La Laguna, Tenerife, Spain \\  Universidad de La Laguna, Dept. de Astrof\'{\i}sica, E-38206 La Laguna, Tenerife, Spain",0000-0003-3044-5150
+Cereskaite,Rasa,R.~Cereskaite,False,"Department of Physics and Astronomy, University of Sussex, Brighton BN1 9QH, U.K",
+Cervantes-Cota,Jorge  L.,J.~L.~Cervantes-Cota,False,"Departamento de F\'{i}sica, Instituto Nacional de Investigaciones Nucleares, Carreterra M\'{e}xico-Toluca S/N, La Marquesa,  Ocoyoacac, Edo. de M\'{e}xico C.P. 52750,  M\'{e}xico",0000-0002-3057-6786
+Chabanier,Solène,S.~Chabanier,False,"Lawrence Berkeley National Laboratory, 1 Cyclotron Road, Berkeley, CA 94720, USA",0000-0002-5692-5243
+Chaussidon,Edmond,E.~Chaussidon,False,"Lawrence Berkeley National Laboratory, 1 Cyclotron Road, Berkeley, CA 94720, USA",0000-0001-8996-4874
+Chaves-Montero,Jonás,J.~Chaves-Montero,False,"Institut de F\'{i}sica d’Altes Energies (IFAE), The Barcelona Institute of Science and Technology, Campus UAB, 08193 Bellaterra Barcelona, Spain",0000-0002-9553-4261
+Chen,Xinyi,X.~Chen,False,"Physics Department, Yale University, P.O. Box 208120, New Haven, CT 06511, USA",
+Claybaugh,Todd,T.~Claybaugh,True,"Lawrence Berkeley National Laboratory, 1 Cyclotron Road, Berkeley, CA 94720, USA",
+Cole,Shaun,S.~Cole,True,"Institute for Computational Cosmology, Department of Physics, Durham University, South Road, Durham DH1 3LE, UK",0000-0002-5954-7903
+Cuceu,Andrei,A.~Cuceu,False,"Center for Cosmology and AstroParticle Physics, The Ohio State University, 191 West Woodruff Avenue, Columbus, OH 43210, USA",0000-0002-2169-0595
+Davis,Tamara,T.~M.~Davis,False,"School of Mathematics and Physics, University of Queensland, 4072, Australia",0000-0002-4213-8783
+Dawson,Kyle,K.~Dawson,True,"Department of Physics and Astronomy, The University of Utah, 115 South 1400 East, Salt Lake City, UT 84112, USA",
+de la Cruz,Rodrigo,R.~de la Cruz,False,"Departamento de F\'{i}sica, Universidad de Guanajuato - DCI, C.P. 37150, Leon, Guanajuato, M\'{e}xico",0000-0001-9908-9129
+de la Macorra,Axel ,A.~de la Macorra,True,"Instituto de F\'{\i}sica, Universidad Nacional Aut\'{o}noma de M\'{e}xico,  Cd. de M\'{e}xico  C.P. 04510,  M\'{e}xico",0000-0002-1769-1640
+de Mattia,Arnaud,A.~de~Mattia,False,"IRFU, CEA, Universit\'{e} Paris-Saclay, F-91191 Gif-sur-Yvette, France",
+Deiosso,Nicola,N.~Deiosso,False,"CIEMAT, Avenida Complutense 40, E-28040 Madrid, Spain",0000-0002-7311-4506
+Demina,Regina,R.~Demina,False,"Department of Physics \& Astronomy, University of Rochester, 206 Bausch and Lomb Hall, P.O. Box 270171, Rochester, NY 14627-0171, USA",
+Dey,Arjun,A.~Dey,True,"NSF's NOIRLab, 950 N. Cherry Ave., Tucson, AZ 85719, USA",0000-0002-4928-4003
+Dey,Biprateep,B.~Dey,True,"Department of Physics \& Astronomy and Pittsburgh Particle Physics, Astrophysics, and Cosmology Center (PITT PACC), University of Pittsburgh, 3941 O'Hara Street, Pittsburgh, PA 15260, USA",0000-0002-5665-7912
+Ding,Zhejie,Z.~Ding,False,None,0000-0002-3369-3718
+Ding,Jiani,J.~Ding,False,"Department of Astronomy and Astrophysics, UCO/Lick Observatory, University of California, 1156 High Street, Santa Cruz, CA 95064, USA",
+Doel,Peter,P.~Doel,True,"Department of Physics \& Astronomy, University College London, Gower Street, London, WC1E 6BT, UK",
+Edelstein,Jerry,J.~Edelstein,True,"Space Sciences Laboratory, University of California, Berkeley, 7 Gauss Way, Berkeley, CA  94720, USA",
+Edelstein,Jerry,J.~Edelstein,True,"University of California, Berkeley, 110 Sproul Hall \#5800 Berkeley, CA 94720, USA",
+Eftekharzadeh,Sarah,S.~Eftekharzadeh,True,"Universities Space Research Association, NASA Ames Research Centre",
+Eisenstein,Daniel,D.~J.~Eisenstein,True,"Center for Astrophysics $|$ Harvard \& Smithsonian, 60 Garden Street, Cambridge, MA 02138, USA",
+Elliott,Ann,A.~Elliott,True,"Department of Physics, The Ohio State University, 191 West Woodruff Avenue, Columbus, OH 43210, USA",0000-0001-6537-6453
+Elliott,Ann,A.~Elliott,True,"The Ohio State University, Columbus, 43210 OH, USA",0000-0001-6537-6453
+Fagrelius,Parker,P.~Fagrelius,True,"NSF's NOIRLab, 950 N. Cherry Ave., Tucson, AZ 85719, USA",
+Fanning,Kevin,K.~Fanning,True,"Kavli Institute for Particle Astrophysics and Cosmology, Stanford University, Menlo Park, CA 94305, USA",0000-0003-2371-3356
+Fanning,Kevin,K.~Fanning,True,"SLAC National Accelerator Laboratory, Menlo Park, CA 94305, USA",0000-0003-2371-3356
+Ferraro,Simone,S.~Ferraro,True,"Lawrence Berkeley National Laboratory, 1 Cyclotron Road, Berkeley, CA 94720, USA",0000-0003-4992-7854
+Ferraro,Simone,S.~Ferraro,True,"University of California, Berkeley, 110 Sproul Hall \#5800 Berkeley, CA 94720, USA",0000-0003-4992-7854
+Ferrer Ereza,Julia ,J.~Ereza,False,"Instituto de Astrof\'{i}sica de Andaluc\'{i}a (CSIC), Glorieta de la Astronom\'{i}a, s/n, E-18008 Granada, Spain",0000-0002-0194-4017
+Findlay,Nathan,N.~Findlay,False,"Institute of Cosmology and Gravitation, University of Portsmouth, Dennis Sciama Building, Portsmouth, PO1 3FX, UK",
+Font-Ribera,Andreu,A.~Font-Ribera,True,"Institut de F\'{i}sica d’Altes Energies (IFAE), The Barcelona Institute of Science and Technology, Campus UAB, 08193 Bellaterra Barcelona, Spain",0000-0002-3033-7312
+Forero Sánchez,Daniel Felipe,D.~Forero-Sánchez,False,"Ecole Polytechnique F\'{e}d\'{e}rale de Lausanne, CH-1015 Lausanne, Switzerland",0000-0001-5957-332X
+Forero-Romero,Jaime E.,J.~E.~Forero-Romero,True,"Departamento de F\'isica, Universidad de los Andes, Cra. 1 No. 18A-10, Edificio Ip, CP 111711, Bogot\'a, Colombia",0000-0002-2890-3725
+Forero-Romero,Jaime E.,J.~E.~Forero-Romero,True,"Observatorio Astron\'omico, Universidad de los Andes, Cra. 1 No. 18A-10, Edificio H, CP 111711 Bogot\'a, Colombia",0000-0002-2890-3725
+Frenk,Carlos,C.~S.~Frenk,False,"Institute for Computational Cosmology, Department of Physics, Durham University, South Road, Durham DH1 3LE, UK",0000-0002-2338-716X
+Garcia-Quintero,Cristhian,C.~Garcia-Quintero,False,"Department of Physics, The University of Texas at Dallas, Richardson, TX 75080, USA",0000-0003-1481-4294
+Gaztañaga,Enrique,E.~Gaztañaga,True,"Institut d'Estudis Espacials de Catalunya (IEEC), 08034 Barcelona, Spain",
+Gaztañaga,Enrique,E.~Gaztañaga,True,"Institute of Cosmology and Gravitation, University of Portsmouth, Dennis Sciama Building, Portsmouth, PO1 3FX, UK",
+Gaztañaga,Enrique,E.~Gaztañaga,True,"Institute of Space Sciences, ICE-CSIC, Campus UAB, Carrer de Can Magrans s/n, 08913 Bellaterra, Barcelona, Spain",
+Gil-Marín,Héctor,H.~Gil-Mar\'in,False,"Instituto de C\`{\i}encias del Cosmoc, (ICCUB) Universidad de Barcelona (IEEC-UB), Mart\'{\i} i Franqu\`{e}s 1, E08028 Barcelona, Spain",0000-0003-0265-6217
+Gontcho A Gontcho,Satya ,S.~Gontcho A Gontcho,True,"Lawrence Berkeley National Laboratory, 1 Cyclotron Road, Berkeley, CA 94720, USA",0000-0003-3142-233X
+Gonzalez-Perez,Violeta,V.~Gonzalez-Perez,False,"Centro de Investigaci\'{o}n Avanzada en F\'{\i}sica Fundamental (CIAFF), Facultad de Ciencias, Universidad Aut\'{o}noma de Madrid, ES-28049 Madrid, Spain",0000-0001-9938-2755
+Gonzalez-Perez,Violeta,V.~Gonzalez-Perez,False,"Instituto de F\'{\i}sica Te\'{o}rica (IFT) UAM/CSIC, Universidad Aut\'{o}noma de Madrid, Cantoblanco, E-28049, Madrid, Spain",0000-0001-9938-2755
+Gordon,Calum,C.~Gordon,False,"Institut de F\'{i}sica d’Altes Energies (IFAE), The Barcelona Institute of Science and Technology, Campus UAB, 08193 Bellaterra Barcelona, Spain",
+Green,Dylan,D.~Green,False,"Department of Physics and Astronomy, University of California, Irvine, 92697, USA",0000-0002-0676-3661
+Gruen,Daniel,D.~Gruen,False,"Excellence Cluster ORIGINS, Boltzmannstrasse 2, D-85748 Garching, Germany",
+Gruen,Daniel,D.~Gruen,False,"University Observatory, Faculty of Physics, Ludwig-Maximilians-Universit\""{a}t, Scheinerstr. 1, 81677 M\""{u}nchen, Germany",
+Gsponer,Rafaela  ,R.~Gsponer,False,"Institute of Cosmology and Gravitation, University of Portsmouth, Dennis Sciama Building, Portsmouth, PO1 3FX, UK",
+Hadzhiyska,Boryana,B.~Hadzhiyska,False,"Lawrence Berkeley National Laboratory, 1 Cyclotron Road, Berkeley, CA 94720, USA",0000-0002-2312-3121
+Hadzhiyska,Boryana,B.~Hadzhiyska,False,"University of California, Berkeley, 110 Sproul Hall \#5800 Berkeley, CA 94720, USA",0000-0002-2312-3121
+Hahn,ChangHoon,C.~Hahn,True,"Department of Astrophysical Sciences, Princeton University, Princeton NJ 08544, USA",0000-0003-1197-0902
+Hanif,Malik Muhammad Sikandar,M.~M.~S~Hanif,False,"University of Michigan, Ann Arbor, MI 48109, USA",0009-0006-2583-5006
+Herrera-Alcantar,Hiram K.,H.~K.~Herrera-Alcantar,False,"Departamento de F\'{i}sica, Universidad de Guanajuato - DCI, C.P. 37150, Leon, Guanajuato, M\'{e}xico",0000-0002-9136-9609
+Honscheid,Klaus,K.~Honscheid,True,"Center for Cosmology and AstroParticle Physics, The Ohio State University, 191 West Woodruff Avenue, Columbus, OH 43210, USA",
+Honscheid,Klaus,K.~Honscheid,True,"Department of Physics, The Ohio State University, 191 West Woodruff Avenue, Columbus, OH 43210, USA",
+Honscheid,Klaus,K.~Honscheid,True,"The Ohio State University, Columbus, 43210 OH, USA",
+Hou,Jiamin,J.~Hou,False,"Department of Astronomy, University of Florida, 211 Bryant Space Science Center, Gainesville, FL 32611, USA",
+Howlett,Cullan,C.~Howlett,False,"School of Mathematics and Physics, University of Queensland, 4072, Australia",0000-0002-1081-9410
+Huterer,Dragan,D.~Huterer,False,"Department of Physics, University of Michigan, Ann Arbor, MI 48109, USA",0000-0001-6558-0112
+Huterer,Dragan,D.~Huterer,False,"University of Michigan, Ann Arbor, MI 48109, USA",0000-0001-6558-0112
+Irsic,Vid,V.~Ir\v{s}i\v{c},False,"Kavli Institute for Cosmology, University of Cambridge, Madingley Road, Cambridge CB3 0HA, UK",0000-0002-5445-461X
+Ishak,Mustapha,M.~Ishak,False,"Department of Physics, The University of Texas at Dallas, Richardson, TX 75080, USA",0000-0002-6024-466X
+Karacayli,Naim Goksel,N.~G.~Kara{\c c}ayl{\i},False,"Center for Cosmology and AstroParticle Physics, The Ohio State University, 191 West Woodruff Avenue, Columbus, OH 43210, USA",0000-0001-7336-8912
+Karacayli,Naim Goksel,N.~G.~Kara{\c c}ayl{\i},False,"Department of Astronomy, The Ohio State University, 4055 McPherson Laboratory, 140 W 18th Avenue, Columbus, OH 43210, USA",0000-0001-7336-8912
+Karacayli,Naim Goksel,N.~G.~Kara{\c c}ayl{\i},False,"Department of Physics, The Ohio State University, 191 West Woodruff Avenue, Columbus, OH 43210, USA",0000-0001-7336-8912
+Karacayli,Naim Goksel,N.~G.~Kara{\c c}ayl{\i},False,"The Ohio State University, Columbus, 43210 OH, USA",0000-0001-7336-8912
+Kent,Stephen,S.~Kent,True,"Department of Astronomy and Astrophysics, University of Chicago, 5640 South Ellis Avenue, Chicago, IL 60637, USA",0000-0003-4207-7420
+Kent,Stephen,S.~Kent,True,"Fermi National Accelerator Laboratory, PO Box 500, Batavia, IL 60510, USA",0000-0003-4207-7420
+Kirkby,David,D.~Kirkby,True,"Department of Physics and Astronomy, University of California, Irvine, 92697, USA",0000-0002-8828-5463
+Kitaura,Francisco-Shu,F.-S.~Kitaura,False,"Departamento de Astrof\'{\i}sica, Universidad de La Laguna (ULL), E-38206, La Laguna, Tenerife, Spain",0000-0002-9994-759X
+Kitaura,Francisco-Shu,F.-S.~Kitaura,False,"Instituto de Astrof\'{i}sica de Canarias, C/ Vía L\'{a}ctea, s/n, E-38205 La Laguna, Tenerife, Spain \\  Universidad de La Laguna, Dept. de Astrof\'{\i}sica, E-38206 La Laguna, Tenerife, Spain",0000-0002-9994-759X
+Kremin,Anthony,A.~Kremin,True,"Lawrence Berkeley National Laboratory, 1 Cyclotron Road, Berkeley, CA 94720, USA",0000-0001-6356-7424
+Krolewski,Alex,A.~Krolewski,False,"Department of Physics and Astronomy, University of Waterloo, 200 University Ave W, Waterloo, ON N2L 3G1, Canada",
+Krolewski,Alex,A.~Krolewski,False,"Perimeter Institute for Theoretical Physics, 31 Caroline St. North, Waterloo, ON N2L 2Y5, Canada",
+Krolewski,Alex,A.~Krolewski,False,"Waterloo Centre for Astrophysics, University of Waterloo, 200 University Ave W, Waterloo, ON N2L 3G1, Canada",
+Lai,Yan,Y.~Lai,False,"School of Mathematics and Physics, University of Queensland, 4072, Australia",
+Lan,Ting-Wen,T.-W.~Lan,False,"Graduate Institute of Astrophysics and Department of Physics, National Taiwan University, No. 1, Sec. 4, Roosevelt Rd., Taipei 10617, Taiwan",0000-0001-8857-7020
+Lang,Dustin,D.~Lang,True,"Perimeter Institute for Theoretical Physics, 31 Caroline St. North, Waterloo, ON N2L 2Y5, Canada",
+Le Goff,Jean-Marc,J.M.~Le~Goff,True,"IRFU, CEA, Universit\'{e} Paris-Saclay, F-91191 Gif-sur-Yvette, France",
+Le Guillou,Laurent,L.~Le~Guillou,True,"Sorbonne Universit\'{e}, CNRS/IN2P3, Laboratoire de Physique Nucl\'{e}aire et de Hautes Energies (LPNHE), FR-75005 Paris, France",0000-0001-7178-8868
+Levi,Michael,Michael~E.~Levi,True,"Lawrence Berkeley National Laboratory, 1 Cyclotron Road, Berkeley, CA 94720, USA",0000-0003-1887-1018
+Li,Ting,T.~S.~Li,True,"Department of Astronomy \& Astrophysics, University of Toronto, Toronto, ON M5S 3H4, Canada",0000-0002-9110-6163
+Linder,Eric,E.~Linder,False,"Lawrence Berkeley National Laboratory, 1 Cyclotron Road, Berkeley, CA 94720, USA",0000-0001-5536-9241
+Linder,Eric,E.~Linder,False,"Space Sciences Laboratory, University of California, Berkeley, 7 Gauss Way, Berkeley, CA  94720, USA",0000-0001-5536-9241
+Linder,Eric,E.~Linder,False,"University of California, Berkeley, 110 Sproul Hall \#5800 Berkeley, CA 94720, USA",0000-0001-5536-9241
+Lodha,Kushal,K.~Lodha,False,"Korea Astronomy and Space Science Institute, 776, Daedeokdae-ro, Yuseong-gu, Daejeon 34055, Republic of Korea",
+Magneville,Christophe,C.~Magneville,True,"IRFU, CEA, Universit\'{e} Paris-Saclay, F-91191 Gif-sur-Yvette, France",
+Manera,Marc,M.~Manera,True,"Departament de F\'{i}sica, Serra H\'{u}nter, Universitat Aut\`{o}noma de Barcelona, 08193 Bellaterra (Barcelona), Spain",0000-0003-4962-8934
+Manera,Marc,M.~Manera,True,"Institut de F\'{i}sica d’Altes Energies (IFAE), The Barcelona Institute of Science and Technology, Campus UAB, 08193 Bellaterra Barcelona, Spain",0000-0003-4962-8934
+Margala,Daniel,D.~Margala,True,"Lawrence Berkeley National Laboratory, 1 Cyclotron Road, Berkeley, CA 94720, USA",0009-0001-5897-1956
+Martini,Paul,P.~Martini,True,"Center for Cosmology and AstroParticle Physics, The Ohio State University, 191 West Woodruff Avenue, Columbus, OH 43210, USA",0000-0002-4279-4182
+Martini,Paul,P.~Martini,True,"Department of Astronomy, The Ohio State University, 4055 McPherson Laboratory, 140 W 18th Avenue, Columbus, OH 43210, USA",0000-0002-4279-4182
+Martini,Paul,P.~Martini,True,"The Ohio State University, Columbus, 43210 OH, USA",0000-0002-4279-4182
+Maus,Mark Lennard,M.~Maus,False,"University of California, Berkeley, 110 Sproul Hall \#5800 Berkeley, CA 94720, USA",
+Medina Varela,Leonel ,L.~Medina-Varela,False,"Department of Physics, The University of Texas at Dallas, Richardson, TX 75080, USA",
+Meisner,Aaron,A.~Meisner,True,"NSF's NOIRLab, 950 N. Cherry Ave., Tucson, AZ 85719, USA",0000-0002-1125-7384
+Mena-Fernández,Juan,J.~Mena-Fern\'andez,False,"Laboratoire de Physique Subatomique et de Cosmologie, 53 Avenue des Martyrs, 38000 Grenoble, France",0000-0001-9497-7266
+Miquel,Ramon,R.~Miquel,True,"Instituci\'{o} Catalana de Recerca i Estudis Avan\c{c}ats, Passeig de Llu\'{\i}s Companys, 23, 08010 Barcelona, Spain",
+Miquel,Ramon,R.~Miquel,True,"Institut de F\'{i}sica d’Altes Energies (IFAE), The Barcelona Institute of Science and Technology, Campus UAB, 08193 Bellaterra Barcelona, Spain",
+Moon,Jeongin,J.~Moon,False,None,
+Moore,Samuel,S.~Moore,False,"Institute for Computational Cosmology, Department of Physics, Durham University, South Road, Durham DH1 3LE, UK",
+Moustakas,John,J.~Moustakas,True,"Department of Physics and Astronomy, Siena College, 515 Loudon Road, Loudonville, NY 12211, USA",0000-0002-2733-4559
+Mudur,Nayantara,N.~Mudur,False,"Center for Astrophysics $|$ Harvard \& Smithsonian, 60 Garden Street, Cambridge, MA 02138, USA",
+Mueller,Eva-Maria,E.~Mueller,False,"Department of Physics and Astronomy, University of Sussex, Brighton BN1 9QH, U.K",
+Muñoz-Gutiérrez,Andrea ,A.~Muñoz-Gutiérrez,True,"Instituto de F\'{\i}sica, Universidad Nacional Aut\'{o}noma de M\'{e}xico,  Cd. de M\'{e}xico  C.P. 04510,  M\'{e}xico",
+Myers,Adam,A.~D.~Myers,True,"Department of Physics \& Astronomy, University  of Wyoming, 1000 E. University, Dept.~3905, Laramie, WY 82071, USA",
+Nadathur,Seshadri,S.~Nadathur,False,"Institute of Cosmology and Gravitation, University of Portsmouth, Dennis Sciama Building, Portsmouth, PO1 3FX, UK",0000-0001-9070-3102
+Napolitano,Lucas,L.~Napolitano,False,"Department of Physics \& Astronomy, University  of Wyoming, 1000 E. University, Dept.~3905, Laramie, WY 82071, USA",0000-0002-5166-8671
+Neveux,Richard,R.~Neveux,False,"Institute for Astronomy, University of Edinburgh, Royal Observatory, Blackford Hill, Edinburgh EH9 3HJ, UK",
+Newman,Jeffrey A.,J.~ A.~Newman,True,"Department of Physics \& Astronomy and Pittsburgh Particle Physics, Astrophysics, and Cosmology Center (PITT PACC), University of Pittsburgh, 3941 O'Hara Street, Pittsburgh, PA 15260, USA",0000-0001-8684-2222
+Nguyen,Minh,M.~Nguyen,False,"University of Michigan, Ann Arbor, MI 48109, USA",
+Niz,Gustavo,G.~Niz,False,"Departamento de F\'{i}sica, Universidad de Guanajuato - DCI, C.P. 37150, Leon, Guanajuato, M\'{e}xico",0000-0002-1544-8946
+Niz,Gustavo,G.~Niz,False,"Instituto Avanzado de Cosmolog\'{\i}a A.~C., San Marcos 11 - Atenas 202. Magdalena Contreras, 10720. Ciudad de M\'{e}xico, M\'{e}xico",0000-0002-1544-8946
+Noriega ,Hernan Enrique ,H.~E.~Noriega,False,"Instituto de Ciencias F\'{\i}sicas, Universidad Aut\'onoma de M\'exico, Cuernavaca, Morelos, 62210, M\'exico",0000-0002-3397-3998
+Noriega ,Hernan Enrique ,H.~E.~Noriega,False,"Instituto de F\'{\i}sica, Universidad Nacional Aut\'{o}noma de M\'{e}xico,  Cd. de M\'{e}xico  C.P. 04510,  M\'{e}xico",0000-0002-3397-3998
+Paillas,Enrique,E.~Paillas,False,"Department of Physics and Astronomy, University of Waterloo, 200 University Ave W, Waterloo, ON N2L 3G1, Canada",0000-0002-4637-2868
+Paillas,Enrique,E.~Paillas,False,"Waterloo Centre for Astrophysics, University of Waterloo, 200 University Ave W, Waterloo, ON N2L 3G1, Canada",0000-0002-4637-2868
+Palanque-Delabrouille,Nathalie,N.~Palanque-Delabrouille,True,"IRFU, CEA, Universit\'{e} Paris-Saclay, F-91191 Gif-sur-Yvette, France",0000-0003-3188-784X
+Palanque-Delabrouille,Nathalie,N.~Palanque-Delabrouille,True,"Lawrence Berkeley National Laboratory, 1 Cyclotron Road, Berkeley, CA 94720, USA",0000-0003-3188-784X
+Pan,Jiaming,J.~Pan,False,"University of Michigan, Ann Arbor, MI 48109, USA",
+Penmetsa,Siddhardha,S.~Penmetsa,False,"Department of Physics and Astronomy, University of Waterloo, 200 University Ave W, Waterloo, ON N2L 3G1, Canada",
+Percival,Will,W.~J.~Percival,True,"Department of Physics and Astronomy, University of Waterloo, 200 University Ave W, Waterloo, ON N2L 3G1, Canada",0000-0002-0644-5727
+Percival,Will,W.~J.~Percival,True,"Perimeter Institute for Theoretical Physics, 31 Caroline St. North, Waterloo, ON N2L 2Y5, Canada",0000-0002-0644-5727
+Percival,Will,W.~J.~Percival,True,"Waterloo Centre for Astrophysics, University of Waterloo, 200 University Ave W, Waterloo, ON N2L 3G1, Canada",0000-0002-0644-5727
+Pieri,Matthew,M.~Pieri,False,"Aix Marseille Univ, CNRS, CNES, LAM, Marseille, France",
+Pinon,Mathilde,M.~Pinon,False,"IRFU, CEA, Universit\'{e} Paris-Saclay, F-91191 Gif-sur-Yvette, France",
+Poppett,Claire,C.~Poppett,True,"Lawrence Berkeley National Laboratory, 1 Cyclotron Road, Berkeley, CA 94720, USA",
+Poppett,Claire,C.~Poppett,True,"Space Sciences Laboratory, University of California, Berkeley, 7 Gauss Way, Berkeley, CA  94720, USA",
+Poppett,Claire,C.~Poppett,True,"University of California, Berkeley, 110 Sproul Hall \#5800 Berkeley, CA 94720, USA",
+Porredon,Anna,A.~Porredon,False,"Institute for Astronomy, University of Edinburgh, Royal Observatory, Blackford Hill, Edinburgh EH9 3HJ, UK",0000-0002-2762-2024
+Porredon,Anna,A.~Porredon,False,"Ruhr University Bochum, Faculty of Physics and Astronomy, Astronomical Institute (AIRUB), German Centre for Cosmological Lensing, 44780 Bochum, Germany",0000-0002-2762-2024
+Porredon,Anna,A.~Porredon,False,"The Ohio State University, Columbus, 43210 OH, USA",0000-0002-2762-2024
+Prada,Francisco,F.~Prada,True,"Instituto de Astrof\'{i}sica de Andaluc\'{i}a (CSIC), Glorieta de la Astronom\'{i}a, s/n, E-18008 Granada, Spain",0000-0001-7145-8674
+Pérez-Fernández,Alejandro,A.~P\'{e}rez-Fern\'{a}ndez,False,"Instituto de F\'{\i}sica, Universidad Nacional Aut\'{o}noma de M\'{e}xico,  Cd. de M\'{e}xico  C.P. 04510,  M\'{e}xico",0009-0006-1331-4035
+Pérez-Fernández,Alejandro,A.~P\'{e}rez-Fern\'{a}ndez,False,None,0009-0006-1331-4035
+Pérez-Ràfols,Ignasi,I.~P\'erez-R\`afols,False,"Departament de F\'isica, EEBE, Universitat Polit\`ecnica de Catalunya, c/Eduard Maristany 10, 08930 Barcelona, Spain",0000-0001-6979-0125
+Rabinowitz,David,D.~Rabinowitz,True,"Physics Department, Yale University, P.O. Box 208120, New Haven, CT 06511, USA",
+Raichoor,Anand,A.~Raichoor,True,"Lawrence Berkeley National Laboratory, 1 Cyclotron Road, Berkeley, CA 94720, USA",0000-0001-5999-7923
+Ramírez Pérez,César ,C.~Ram\'irez-P\'erez,False,"Institut de F\'{i}sica d’Altes Energies (IFAE), The Barcelona Institute of Science and Technology, Campus UAB, 08193 Bellaterra Barcelona, Spain",
+Ramírez Solano,Sadi,S.~Ramirez-Solano,False,"Instituto de F\'{\i}sica, Universidad Nacional Aut\'{o}noma de M\'{e}xico,  Cd. de M\'{e}xico  C.P. 04510,  M\'{e}xico",
+Rashkovetskyi,Michael,M.~Rashkovetskyi,False,"Center for Astrophysics $|$ Harvard \& Smithsonian, 60 Garden Street, Cambridge, MA 02138, USA",0000-0001-7144-2349
+Ravoux,Corentin,C.~Ravoux,False,"Aix Marseille Univ, CNRS/IN2P3, CPPM, Marseille, France",0000-0002-3500-6635
+Ravoux,Corentin,C.~Ravoux,False,"IRFU, CEA, Universit\'{e} Paris-Saclay, F-91191 Gif-sur-Yvette, France",0000-0002-3500-6635
+Rezaie,Mehdi,M.~Rezaie,True,"Department of Physics, Kansas State University, 116 Cardwell Hall, Manhattan, KS 66506, USA",0000-0001-5589-7116
+Rich,James,J.~Rich,False,"IRFU, CEA, Universit\'{e} Paris-Saclay, F-91191 Gif-sur-Yvette, France",
+Rich,James,J.~Rich,False,"Sorbonne Universit\'{e}, CNRS/IN2P3, Laboratoire de Physique Nucl\'{e}aire et de Hautes Energies (LPNHE), FR-75005 Paris, France",
+Rocher,Antoine,A.~Rocher,False,"Ecole Polytechnique F\'{e}d\'{e}rale de Lausanne, CH-1015 Lausanne, Switzerland",0000-0003-4349-6424
+Rodríguez Martínez,Fanny Arlin,F.~Rodríguez Martínez,False,"Instituto de F\'{\i}sica, Universidad Nacional Aut\'{o}noma de M\'{e}xico,  Cd. de M\'{e}xico  C.P. 04510,  M\'{e}xico",
+Roe,Natalie,N.A.~Roe,True,"Lawrence Berkeley National Laboratory, 1 Cyclotron Road, Berkeley, CA 94720, USA",
+Ross,Ashley J.,A.~J.~Ross,True,"Center for Cosmology and AstroParticle Physics, The Ohio State University, 191 West Woodruff Avenue, Columbus, OH 43210, USA",
+Ross,Ashley J.,A.~J.~Ross,True,"Department of Astronomy, The Ohio State University, 4055 McPherson Laboratory, 140 W 18th Avenue, Columbus, OH 43210, USA",
+Ross,Ashley J.,A.~J.~Ross,True,"The Ohio State University, Columbus, 43210 OH, USA",
+Rossi,Graziano,G.~Rossi,True,"Department of Physics and Astronomy, Sejong University, Seoul, 143-747, Korea",
+Ruggeri,Rossana,R.~Ruggeri,False,"Centre for Astrophysics \& Supercomputing, Swinburne University of Technology, P.O. Box 218, Hawthorn, VIC 3122, Australia",0000-0002-0394-0896
+Ruggeri,Rossana,R.~Ruggeri,False,"School of Mathematics and Physics, University of Queensland, 4072, Australia",0000-0002-0394-0896
+Ruhlmann-Kleider,Vanina,V.~Ruhlmann-Kleider,True,"IRFU, CEA, Universit\'{e} Paris-Saclay, F-91191 Gif-sur-Yvette, France",0009-0000-6063-6121
+Samushia,Lado,L.~Samushia,False,"Abastumani Astrophysical Observatory, Tbilisi, GE-0179, Georgia",0000-0002-1609-5687
+Samushia,Lado,L.~Samushia,False,"Department of Physics, Kansas State University, 116 Cardwell Hall, Manhattan, KS 66506, USA",0000-0002-1609-5687
+Samushia,Lado,L.~Samushia,False,"Faculty of Natural Sciences and Medicine, Ilia State University, 0194 Tbilisi, Georgia",0000-0002-1609-5687
+Sanchez,Eusebio,E.~Sanchez,True,"CIEMAT, Avenida Complutense 40, E-28040 Madrid, Spain",0000-0002-9646-8198
+Saulder,Christoph,C.~Saulder,False,None,0000-0002-0408-5633
+Scholte,Dirk,D.~Scholte,False,"Department of Physics \& Astronomy, University College London, Gower Street, London, WC1E 6BT, UK",
+Schubnell,Michael,M.~Schubnell,True,"Department of Physics, University of Michigan, Ann Arbor, MI 48109, USA",
+Schubnell,Michael,M.~Schubnell,True,"University of Michigan, Ann Arbor, MI 48109, USA",
+Shafieloo,Arman,A.~Shafieloo,False,"Korea Astronomy and Space Science Institute, 776, Daedeokdae-ro, Yuseong-gu, Daejeon 34055, Republic of Korea",0000-0001-6815-0337
+Sharples,Ray,R.~Sharples,True,"Centre for Advanced Instrumentation, Department of Physics, Durham University, South Road, Durham DH1 3LE, UK",0000-0003-3449-8583
+Sharples,Ray,R.~Sharples,True,"Institute for Computational Cosmology, Department of Physics, Durham University, South Road, Durham DH1 3LE, UK",0000-0003-3449-8583
+Silber,Joseph Harry,J.~Silber,True,"Lawrence Berkeley National Laboratory, 1 Cyclotron Road, Berkeley, CA 94720, USA",0000-0002-3461-0320
+Sinigaglia,Francesco,F.~Sinigaglia,False,"Instituto de Astrof\'{i}sica de Canarias, C/ Vía L\'{a}ctea, s/n, E-38205 La Laguna, Tenerife, Spain \\  Universidad de La Laguna, Dept. de Astrof\'{\i}sica, E-38206 La Laguna, Tenerife, Spain",0000-0002-0639-8043
+Smith,Alex,A.~Smith,True,"Institute for Computational Cosmology, Department of Physics, Durham University, South Road, Durham DH1 3LE, UK",0000-0002-3712-6892
+Sprayberry,David,D.~Sprayberry,True,"NSF's NOIRLab, 950 N. Cherry Ave., Tucson, AZ 85719, USA",
+Swanson,Jaide,J.~Swanson,False,"Department of Physics \& Astronomy, Ohio University, Athens, OH 45701, USA",
+Tan,Ting,T.~Tan,False,"IRFU, CEA, Universit\'{e} Paris-Saclay, F-91191 Gif-sur-Yvette, France",
+Tarlé,Gregory,G.~Tarl\'{e},True,"University of Michigan, Ann Arbor, MI 48109, USA",0000-0003-1704-0781
+Taylor,Peter,P.~Taylor,False,"The Ohio State University, Columbus, 43210 OH, USA",
+Trusov,Svyatoslav,S.~Trusov,False,"Sorbonne Universit\'{e}, CNRS/IN2P3, Laboratoire de Physique Nucl\'{e}aire et de Hautes Energies (LPNHE), FR-75005 Paris, France",
+Vaisakh,Rajeev,R.~Vaisakh,False,"Department of Physics, Southern Methodist University, 3215 Daniel Avenue, Dallas, TX 75275, USA",0009-0001-2732-8431
+Valcin,David,D.~Valcin,False,"Department of Physics \& Astronomy, Ohio University, Athens, OH 45701, USA",0000-0003-0129-0620
+Valdes,Francisco,F.~Valdes,False,"NSF's NOIRLab, 950 N. Cherry Ave., Tucson, AZ 85719, USA",0000-0001-5567-1301
+Vargas Magana,Mariana ,M.~Vargas-Maga\~na,True,"Instituto de F\'{\i}sica, Universidad Nacional Aut\'{o}noma de M\'{e}xico,  Cd. de M\'{e}xico  C.P. 04510,  M\'{e}xico",0000-0003-3841-1836
+Verde,Licia,L.~Verde,False,"Instituto de C\`{\i}encias del Cosmoc, (ICCUB) Universidad de Barcelona (IEEC-UB), Mart\'{\i} i Franqu\`{e}s 1, E08028 Barcelona, Spain",0000-0003-2601-8770
+Verde,Licia,L.~Verde,False,"Instituci\'{o} Catalana de Recerca i Estudis Avan\c{c}ats, Passeig de Llu\'{\i}s Companys, 23, 08010 Barcelona, Spain",0000-0003-2601-8770
+Walther,Michael,M.~Walther,False,"Excellence Cluster ORIGINS, Boltzmannstrasse 2, D-85748 Garching, Germany",0000-0002-1748-3745
+Walther,Michael,M.~Walther,False,"University Observatory, Faculty of Physics, Ludwig-Maximilians-Universit\""{a}t, Scheinerstr. 1, 81677 M\""{u}nchen, Germany",0000-0002-1748-3745
+Wang,Mike Shengbo,M.~S.~Wang,False,"Institute for Astronomy, University of Edinburgh, Royal Observatory, Blackford Hill, Edinburgh EH9 3HJ, UK",0000-0002-2652-4043
+Wang,Ben,B.~Wang,False,"Beihang University, Beijing 100191, China",0000-0003-4877-1659
+Wang,Ben,B.~Wang,False,"Department of Astronomy, Tsinghua University, 30 Shuangqing Road, Haidian District, Beijing, China, 100190",0000-0003-4877-1659
+Weaver,Benjamin Alan,B.~A.~Weaver,True,"NSF's NOIRLab, 950 N. Cherry Ave., Tucson, AZ 85719, USA",
+Weaverdyck,Noah,N.~Weaverdyck,False,"Lawrence Berkeley National Laboratory, 1 Cyclotron Road, Berkeley, CA 94720, USA",
+Weinberg,David,D.~H.~Weinberg,False,"Department of Astronomy, The Ohio State University, 4055 McPherson Laboratory, 140 W 18th Avenue, Columbus, OH 43210, USA",0000-0001-7775-7261
+Weinberg,David,D.~H.~Weinberg,False,"The Ohio State University, Columbus, 43210 OH, USA",0000-0001-7775-7261
+White,Martin J.,M.~White,True,"Department of Physics, University of California, Berkeley, 366 LeConte Hall MC 7300, Berkeley, CA 94720-7300, USA",0000-0001-9912-5070
+White,Martin J.,M.~White,True,"University of California, Berkeley, 110 Sproul Hall \#5800 Berkeley, CA 94720, USA",0000-0001-9912-5070
+Yu,Jiaxi,J.~Yu,False,"Ecole Polytechnique F\'{e}d\'{e}rale de Lausanne, CH-1015 Lausanne, Switzerland",
+Yu,Yu,Y.~Yu,False,"Department of Astronomy, School of Physics and Astronomy, Shanghai Jiao Tong University, Shanghai 200240, China",
+Yuan,Sihan,S.~Yuan,False,"SLAC National Accelerator Laboratory, Menlo Park, CA 94305, USA",0000-0002-5992-7586
+Yèche,Christophe,C.~Yèche,True,"IRFU, CEA, Universit\'{e} Paris-Saclay, F-91191 Gif-sur-Yvette, France",0000-0001-5146-8533
+Zaborowski,Erik,E.~Zaborowski,False,"The Ohio State University, Columbus, 43210 OH, USA",
+Zarrouk,Pauline,P.~Zarrouk,True,"Sorbonne Universit\'{e}, CNRS/IN2P3, Laboratoire de Physique Nucl\'{e}aire et de Hautes Energies (LPNHE), FR-75005 Paris, France",0000-0002-7305-9578
+Zhang,Hanyu,H.~Zhang,False,"Department of Physics and Astronomy, University of Waterloo, 200 University Ave W, Waterloo, ON N2L 3G1, Canada",0000-0001-6847-5254
+Zhao,Cheng,C.~Zhao,False,"Department of Astronomy, Tsinghua University, 30 Shuangqing Road, Haidian District, Beijing, China, 100190",0000-0002-1991-7295
+Zhao,Ruiyang,R.~Zhao,False,"National Astronomical Observatories, Chinese Academy of Sciences, A20 Datun Rd., Chaoyang District, Beijing, 100012, P.R. China",0000-0002-7284-7265
+Zhou,Rongpu,R.~Zhou,True,"Lawrence Berkeley National Laboratory, 1 Cyclotron Road, Berkeley, CA 94720, USA",0000-0001-5381-4372
+Zhuang,Tianke,T.~Zhuang,False,"University of Michigan, Ann Arbor, MI 48109, USA",
+Zou,Hu,H.~Zou,True,"National Astronomical Observatories, Chinese Academy of Sciences, A20 Datun Rd., Chaoyang District, Beijing, 100012, P.R. China",0000-0002-6684-3997

--- a/DESItests/example_firsttier.csv
+++ b/DESItests/example_firsttier.csv
@@ -1,0 +1,23 @@
+Lastname,Firstname,Authorname,JoinedAsBuilder,Affiliation,ORCID,FirstTier
+Adame,Adrián Gutiérrez,A.~G.~Adame,False,"Instituto de F\'{\i}sica Te\'{o}rica (IFT) UAM/CSIC, Universidad Aut\'{o}noma de Madrid, Cantoblanco, E-28049, Madrid, Spain",,
+Aguilar,Jessica Nicole,J.~Aguilar,True,"Lawrence Berkeley National Laboratory, 1 Cyclotron Road, Berkeley, CA 94720, USA",,
+Ahlen,Steven,S.~Ahlen,True,"Physics Dept., Boston University, 590 Commonwealth Avenue, Boston, MA 02215, USA",0000-0001-6098-7247,2
+Alam,Shadab,S.~Alam,False,"Tata Institute of Fundamental Research, Homi Bhabha Road, Mumbai 400005, India",0000-0002-3757-6359,
+Alexander,David,D.~M.~Alexander,False,"Centre for Extragalactic Astronomy, Department of Physics, Durham University, South Road, Durham, DH1 3LE, UK",0000-0002-5896-6313,3
+Alexander,David,D.~M.~Alexander,False,"Institute for Computational Cosmology, Department of Physics, Durham University, South Road, Durham DH1 3LE, UK",0000-0002-5896-6313,3
+Alvarez,Marcelo,M.~Alvarez,True,"Lawrence Berkeley National Laboratory, 1 Cyclotron Road, Berkeley, CA 94720, USA",,
+Alves,Otávio,O.~Alves,False,"University of Michigan, Ann Arbor, MI 48109, USA",,
+Anand,Abhijeet,A.~Anand,False,"Lawrence Berkeley National Laboratory, 1 Cyclotron Road, Berkeley, CA 94720, USA",0000-0003-2923-1585,
+Andrade,Uendert,U.~Dos Santos Andrade,False,"University of Michigan, Ann Arbor, MI 48109, USA",,
+Armengaud,Eric,E.~Armengaud,False,"IRFU, CEA, Universit\'{e} Paris-Saclay, F-91191 Gif-sur-Yvette, France",0000-0001-7600-5148,
+Avila,Santiago,S.~Avila,False,"Institut de F\'{i}sica d’Altes Energies (IFAE), The Barcelona Institute of Science and Technology, Campus UAB, 08193 Bellaterra Barcelona, Spain",0000-0001-5043-3662,
+Aviles,Alejandro,A.~Aviles,False,"Instituto de Ciencias F\'{\i}sicas, Universidad Aut\'onoma de M\'exico, Cuernavaca, Morelos, 62210, M\'exico",0000-0001-5998-3986,
+Awan,Humna,H.~Awan,False,"University of Michigan, Ann Arbor, MI 48109, USA",,
+Bahr-Kalus,Benedict,B.~Bahr-Kalus,False,"Universit\’e Claude Bernard Lyon 1, CNRS/IN2P3, IP2I, Lyon, France",0000-0002-4578-4019,
+Bailey,Stephen,S.~Bailey,True,"Lawrence Berkeley National Laboratory, 1 Cyclotron Road, Berkeley, CA 94720, USA",0000-0003-4162-6619,1
+Bault,Abigail,A.~Bault,True,"Department of Physics and Astronomy, University of California, Irvine, 92697, USA",0000-0002-9964-1005,
+Bautista,Julian,J.~Bautista,False,"Aix Marseille Univ, CNRS/IN2P3, CPPM, Marseille, France",,
+Behera,Jayashree,J.~Behera,False,"Department of Physics, Kansas State University, 116 Cardwell Hall, Manhattan, KS 66506, USA",,4
+BenZvi,Segev,S.~BenZvi,True,"Department of Physics \& Astronomy, University of Rochester, 206 Bausch and Lomb Hall, P.O. Box 270171, Rochester, NY 14627-0171, USA",0000-0001-5537-4710,
+Beutler,Florian,F.~Beutler,False,"Institute for Astronomy, University of Edinburgh, Royal Observatory, Blackford Hill, Edinburgh EH9 3HJ, UK",0000-0003-0467-5438,
+Bianchi,Davide,D.~Bianchi,False,"Dipartimento di Fisica ``Aldo Pontremoli'', Universit\`a degli Studi di Milano, Via Celoria 16, I-20133 Milano, Italy",0000-0001-9712-0006,

--- a/README.DES.md
+++ b/README.DES.md
@@ -1,0 +1,71 @@
+[![Build](https://github.com/DarkEnergySurvey/mkauthlist/actions/workflows/python-package.yml/badge.svg)](https://github.com/DarkEnergySurvey/mkauthlist/actions/workflows/python-package.yml)
+[![PyPI](https://img.shields.io/pypi/v/mkauthlist.svg)](https://pypi.python.org/pypi/mkauthlist)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](../../)
+
+mkauthlist
+==========
+
+Make long latex author lists from csv files.
+
+Installation
+------------
+
+The ``mkauthlist`` script is distributed via ``pip`` and should work on Python 2.7 or later:
+
+```text
+> pip install mkauthlist
+```
+
+You can also clone the repository and install by hand:
+
+```text
+> git clone https://github.com/DarkEnergySurvey/mkauthlist.git
+> cd mkauthlist
+> python setup.py install
+```
+
+Usage
+-----
+
+The core usage is to transform a pre-sorted file of comma separated values into an author list suitable for input in the latex. The ``mkauthlist`` script provides several options for more complicated operations when generating the list. To view all the options:
+
+```text
+> mkauthlist --help
+```
+
+Examples
+--------
+
+### General Use
+
+Start with the author list in comma separated value (CSV) format. An example author list file is provided in [data/example_author_list.csv](data/example_author_list.csv) (DES members can see the PubDB system [here](http://dbweb6.fnal.gov:8080/DESPub/app/PB/pub/author_list/DES-2015-0109_author_list.csv?pubid=109)).
+
+```text
+> mkauthlist -f --doc -j emulateapj --sort example_author_list.csv example_author_list.tex
+> pdflatex example_author_list.tex
+```
+
+The output should looks something like this:
+
+![](data/example_author_list.png)
+
+### Ordering and Sorting
+
+By default, `mkauthlist` preserves the ordering of the input CSV file. However, it is often necessary to manipulate the order of the author list. While this can be done directly by editing the CSV file,  `mkauthlist` also provides some pre-designed functionality for sorting and ordering author lists.
+
+It is possible to alphabetically sort the entire author list using the `-s, --sort` flag. This was done in the previous example, and is shown again here for clarity:
+```
+> mkauthlist --sort example_author_list.csv example_author_list.tex
+```
+Additionally, it is possible to alphabetically sort only the authors identified as "builders" (`JoinedAsBuilder ==  'True'`) using the `-sb, --sort-builder` flag (for DES author lists this is usually already done in the generation of the CSV file). 
+```
+> mkauthlist --sort-builder example_author_list.csv example_author_list.tex
+```
+It is often necessary to place a few key authors at the front of the author list. This can be done using an auxiliary author order file (i.e., `--aux order.csv`). Here, `order.csv` is a one-per-line list of author last names (and optionally, first names). Authors with names in `order.csv` will be moved to the front of the author list and placed in the order specified in `order.csv`.
+```
+> mkauthlist --aux order.csv example_author_list.csv example_author_list.tex
+```
+It is possible to combine options in order to place several authors first and order the rest of the list alphabetically
+```
+> mkauthlist --sort --aux order.csv example_author_list.csv example_author_list.tex
+```

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Usage
 
 In the directory DESItests you may find examples for KP (alphabetical) and first tier papers. For KPs in jcap format and considering ORCID numbers run
 
-
 ```text
 > mkauthlist -f --sort --orcid -j jcap example_alphabetical.csv example_alphabetical.tex
 ```
@@ -43,4 +42,16 @@ For firs tier papers, edit the csv file to add a new column called FirstTier, an
 ```text
 > mkauthlist -f --sort-firsttier --orcid -j jcap example_firsttier.csv example_firsttier.tex
 ```
+
+To send affiliations to an appendix use
+```text
+> mkauthlist -f --sort --orcid -j jcap.appendix example_alphabetical.csv example_alphabetical.tex
+```
+If you want the same for a first author list, change -sort by --sort-firsttier, the email and do not add the DESI collaboration author. 
+
+
+Packages
+-----
+Running with jcap.appendices and orcid needs the commands \usepackage{hanging} and \usepackage{orcidlink} respectively.
+
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-[![Build](https://github.com/DarkEnergySurvey/mkauthlist/actions/workflows/python-package.yml/badge.svg)](https://github.com/DarkEnergySurvey/mkauthlist/actions/workflows/python-package.yml)
-[![PyPI](https://img.shields.io/pypi/v/mkauthlist.svg)](https://pypi.python.org/pypi/mkauthlist)
+[![Build](https://github.com/cosmodesi/mkauthlist/actions/workflows/python-package.yml/badge.svg)](https://github.com/cosmodesi/mkauthlist/actions/workflows/python-package.yml)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../../)
 
 mkauthlist
@@ -10,48 +9,63 @@ Make long latex author lists from csv files.
 Installation
 ------------
 
-Get the latest version of DESI's mkauthlist from the DESI Publication Board wiki page.
+Clone or download this github repository: <https://github.com/cosmodesi/mkauthlist>.
 
-Do no use "pip install mkauthlist" because that will use the DES code.
+Do not use `pip install mkauthlist` because that will use the DES code.
 
-After uncompressing it, you may want to set an enviroment to run it using
+You may want to set a virtual enviroment to run it using
 
-```text
-> cd mkauthlist
-> python3 -m venv mkauthlistDESI
-> source mkauthlistDESI/bin/activate
+```shell
+python3 -m venv mkauthlistDESI
+source mkauthlistDESI/bin/activate
 ```
 
 Then you can simply install it by
 
-```text
-> python3 setup.py install
+```shell
+python3 -m pip install .
 ```
+With this, if the code is changed/updated, for changes to take effect you will need to re-install.
+To avoid this, you can use
+```shell
+python3 -m pip install -e .
+```
+
+If you do not worry about conflicts with the DES version, you can install the code with one of the commands above without setting up a virtual environment.
 
 Usage
 -----
 
-In the directory DESItests you may find examples for KP (alphabetical) and first tier papers. For KPs in jcap format and considering ORCID numbers run
+If you download a CSV file from the DESI PubDB you should **remove the empty lines with a CSV editor** before using this script.
 
-```text
-> mkauthlist -f --sort --orcid -j jcap example_alphabetical.csv example_alphabetical.tex
+In the directory `DESItests` you may find examples for KP (alphabetical) and first tier papers.
+
+For KPs in JCAP format and including ORCID numbers run
+
+```shell
+mkauthlist -f --sort --orcid -j jcap example_alphabetical.csv example_alphabetical.tex
 ```
 
-For firs tier papers, edit the csv file to add a new column called FirstTier, and assign natural numbers to the first tier according to their ordering (see example_firsttier.csv). For first tier papers in jcap with orcid numbers run
+For first tier papers, edit the csv file to add a new column called `FirstTier`, and assign natural numbers to the first tier according to their ordering (see example_firsttier.csv).
+For first tier papers in JCAP with ORCID numbers run
 
-```text
-> mkauthlist -f --sort-firsttier --orcid -j jcap example_firsttier.csv example_firsttier.tex
+```shell
+mkauthlist -f --sort-firsttier --orcid -j jcap example_firsttier.csv example_firsttier.tex
 ```
 
 To send affiliations to an appendix use
-```text
-> mkauthlist -f --sort --orcid -j jcap.appendix example_alphabetical.csv example_alphabetical.tex
+```shell
+mkauthlist -f --sort --orcid -j jcap.appendix example_alphabetical.csv example_alphabetical_appendix.tex
 ```
-If you want the same for a first author list, change -sort by --sort-firsttier, the email and do not add the DESI collaboration author. 
+or
+```shell
+mkauthlist -f --sort-firsttier --orcid -j jcap.appendix example_firsttier.csv example_firsttier_appendix.tex
+```
+respectively.
 
 
-Packages
+Additional TeX packages
 -----
-Running with jcap.appendices and orcid needs the commands \usepackage{hanging} and \usepackage{orcidlink} respectively.
+The output with the `--orcid` option requires `\usepackage{orcidlink}` in the TeX preamble.
 
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ For first-tier papers in JCAP with ORCID numbers run
 mkauthlist -f --sort-firsttier --orcid -j jcap example_firsttier.csv example_firsttier.tex
 ```
 
+You may also want to exclude the collaboration name by adding the `-nc`, `--nocollab` or `--nocollaboration` flag.
+
 To send affiliations to an appendix use
 ```shell
 mkauthlist -f --sort --orcid -j jcap.appendix example_alphabetical.csv example_alphabetical_appendix.tex
@@ -69,6 +71,7 @@ or
 mkauthlist -f --sort-firsttier -j arxiv example_firsttier.csv example_firsttier.txt
 ```
 respectively.
+In the latter case, you may also want to exclude the collaboration name by adding the `-nc`, `--nocollab` or `--nocollaboration` flag.
 
 Additional TeX packages
 -----

--- a/README.md
+++ b/README.md
@@ -63,7 +63,15 @@ mkauthlist -f --sort-firsttier --orcid -j jcap.appendix example_firsttier.csv ex
 ```
 respectively.
 
-To generate the author list for arXiv, use `-j arxiv` (instead of `-j jcap` or `-j jcap.appendix`) with the same options (except `--orcid`).
+To generate the author list for arXiv, use `-j arxiv` with the same sorting options, i.e.
+```shell
+mkauthlist -f --sort -j arxiv example_alphabetical.csv example_alphabetical.txt
+```
+or
+```shell
+mkauthlist -f --sort-firsttier -j arxiv example_firsttier.csv example_firsttier.txt
+```
+respectively.
 
 Additional TeX packages
 -----

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ mkauthlist -f --sort-firsttier --orcid -j jcap.appendix example_firsttier.csv ex
 ```
 respectively.
 
+To generate the author list for arXiv, use `-j arxiv` (instead of `-j jcap` or `-j jcap.appendix`) with the same options (except `--orcid`).
 
 Additional TeX packages
 -----

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ For KPs in JCAP format and including ORCID numbers run
 mkauthlist -f --sort --orcid -j jcap example_alphabetical.csv example_alphabetical.tex
 ```
 
-For first tier papers, edit the csv file to add a new column called `FirstTier`, and assign natural numbers to the first tier according to their ordering (see example_firsttier.csv).
-For first tier papers in JCAP with ORCID numbers run
+For first-tier author papers, edit the CSV file to add a new column called `FirstTier`, and assign natural numbers to the first-tier authors according to their ordering (see `example_firsttier.csv` in `DESItests`).
+For first-tier papers in JCAP with ORCID numbers run
 
 ```shell
 mkauthlist -f --sort-firsttier --orcid -j jcap example_firsttier.csv example_firsttier.tex

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Make long latex author lists from csv files.
 Installation
 ------------
 
-Clone or download this github repository: <https://github.com/cosmodesi/mkauthlist>.
+Clone or download this GitHub repository: <https://github.com/cosmodesi/mkauthlist>.
 
-Do not use `pip install mkauthlist` because that will use the DES code.
+Do not use `pip install mkauthlist`, because that will install the DES version.
 
-You may want to set a virtual enviroment to run it using
+You may want to set a virtual environment to run it using
 
 ```shell
 python3 -m venv mkauthlistDESI
@@ -25,34 +25,42 @@ Then you can simply install it by
 ```shell
 python3 -m pip install .
 ```
-If the code is changed/updated, you will need to re-install for changes to take effect.
+If the code is changed/updated, you will need to reinstall for the changes to take effect.
 The editable/developer installation (`pip install -e .`) does not seem to help avoid the re-installation in some cases.
+
+You can also install from GitHub without cloning or downloading the repository:
+
+```shell
+python3 -m pip install git+https://github.com/cosmodesi/mkauthlist.git
+```
 
 If you do not worry about conflicts with the DES version, you can install the code with one of the commands above without setting up a virtual environment.
 
 Usage
 -----
 
-If you download a CSV file from the DESI PubDB you should **remove the empty lines with a CSV editor** before using this script.
+If you download a CSV file from the DESI PubDB, you should **remove the empty lines with a CSV editor** before using this script.
+For example, you may find the "Edit CSV" and "Rainbow CSV" extensions in VS Code helpful for this.
 
-In the directory `DESItests` you may find examples for KP (alphabetical) and first tier papers.
+In the `DESItests` directory, you may find examples for KP (alphabetical) and first-tier papers.
 
-For KPs in JCAP format and including ORCID numbers run
+For the key papers (KP) in JCAP format with ORCID numbers, run
 
 ```shell
 mkauthlist -f --sort --orcid -j jcap example_alphabetical.csv example_alphabetical.tex
 ```
 
 For first-tier author papers, edit the CSV file to add a new column called `FirstTier`, and assign natural numbers to the first-tier authors according to their ordering (see `example_firsttier.csv` in `DESItests`).
-For first-tier papers in JCAP with ORCID numbers run
+For first-tier papers in JCAP with ORCID numbers, run
 
 ```shell
 mkauthlist -f --sort-firsttier --orcid -j jcap example_firsttier.csv example_firsttier.tex
 ```
 
 You may also want to exclude the collaboration name by adding the `-nc`, `--nocollab` or `--nocollaboration` flag.
+(The collaboration name does not appear for JCAP specifically, but this can be helpful with other journal formats.)
 
-To send affiliations to an appendix use
+To send affiliations to an appendix, use
 ```shell
 mkauthlist -f --sort --orcid -j jcap.appendix example_alphabetical.csv example_alphabetical_appendix.tex
 ```

--- a/README.md
+++ b/README.md
@@ -10,62 +10,37 @@ Make long latex author lists from csv files.
 Installation
 ------------
 
-The ``mkauthlist`` script is distributed via ``pip`` and should work on Python 2.7 or later:
+Get the latest version of DESI's mkauthlist from the DESI Publication Board wiki page.
+
+Do no use "pip install mkauthlist" because that will use the DES code.
+
+After uncompressing it, you may want to set an enviroment to run it using
 
 ```text
-> pip install mkauthlist
+> cd mkauthlist
+> python3 -m venv mkauthlistDESI
+> source mkauthlistDESI/bin/activate
 ```
 
-You can also clone the repository and install by hand:
+Then you can simply install it by
 
 ```text
-> git clone https://github.com/DarkEnergySurvey/mkauthlist.git
-> cd mkauthlist
-> python setup.py install
+> python3 setup.py install
 ```
 
 Usage
 -----
 
-The core usage is to transform a pre-sorted file of comma separated values into an author list suitable for input in the latex. The ``mkauthlist`` script provides several options for more complicated operations when generating the list. To view all the options:
+In the directory DESItests you may find examples for KP (alphabetical) and first tier papers. For KPs in jcap format and considering ORCID numbers run
+
 
 ```text
-> mkauthlist --help
+> mkauthlist -f --sort --orcid -j jcap example_alphabetical.csv example_alphabetical.tex
 ```
 
-Examples
---------
-
-### General Use
-
-Start with the author list in comma separated value (CSV) format. An example author list file is provided in [data/example_author_list.csv](data/example_author_list.csv) (DES members can see the PubDB system [here](http://dbweb6.fnal.gov:8080/DESPub/app/PB/pub/author_list/DES-2015-0109_author_list.csv?pubid=109)).
+For firs tier papers, edit the csv file to add a new column called FirstTier, and assign natural numbers to the first tier according to their ordering (see example_firsttier.csv). For first tier papers in jcap with orcid numbers run
 
 ```text
-> mkauthlist -f --doc -j emulateapj --sort example_author_list.csv example_author_list.tex
-> pdflatex example_author_list.tex
+> mkauthlist -f --sort-firsttier --orcid -j jcap example_firsttier.csv example_firsttier.tex
 ```
 
-The output should looks something like this:
-
-![](data/example_author_list.png)
-
-### Ordering and Sorting
-
-By default, `mkauthlist` preserves the ordering of the input CSV file. However, it is often necessary to manipulate the order of the author list. While this can be done directly by editing the CSV file,  `mkauthlist` also provides some pre-designed functionality for sorting and ordering author lists.
-
-It is possible to alphabetically sort the entire author list using the `-s, --sort` flag. This was done in the previous example, and is shown again here for clarity:
-```
-> mkauthlist --sort example_author_list.csv example_author_list.tex
-```
-Additionally, it is possible to alphabetically sort only the authors identified as "builders" (`JoinedAsBuilder ==  'True'`) using the `-sb, --sort-builder` flag (for DES author lists this is usually already done in the generation of the CSV file). 
-```
-> mkauthlist --sort-builder example_author_list.csv example_author_list.tex
-```
-It is often necessary to place a few key authors at the front of the author list. This can be done using an auxiliary author order file (i.e., `--aux order.csv`). Here, `order.csv` is a one-per-line list of author last names (and optionally, first names). Authors with names in `order.csv` will be moved to the front of the author list and placed in the order specified in `order.csv`.
-```
-> mkauthlist --aux order.csv example_author_list.csv example_author_list.tex
-```
-It is possible to combine options in order to place several authors first and order the rest of the list alphabetically
-```
-> mkauthlist --sort --aux order.csv example_author_list.csv example_author_list.tex
-```

--- a/README.md
+++ b/README.md
@@ -25,11 +25,8 @@ Then you can simply install it by
 ```shell
 python3 -m pip install .
 ```
-With this, if the code is changed/updated, for changes to take effect you will need to re-install.
-To avoid this, you can use
-```shell
-python3 -m pip install -e .
-```
+If the code is changed/updated, you will need to re-install for changes to take effect.
+The editable/developer installation (`pip install -e .`) does not seem to help avoid the re-installation in some cases.
 
 If you do not worry about conflicts with the DES version, you can install the code with one of the commands above without setting up a virtual environment.
 

--- a/bin/mkauthorxml.py
+++ b/bin/mkauthorxml.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+
+"""
+python script to create the author.xml file for a paper written by a large 
+collaboration for an APS journal
+
+The author.xml format is described here:
+  https://github.com/inspirehep/author.xml
+"""
+
+import re
+import sys
+import os
+from datetime import date
+import xml.etree.ElementTree as ET
+from xml.dom import minidom
+from collections import OrderedDict
+import argparse
+
+def pretty_print_xml(elem):
+    """
+    Return a nicely formatted XML string for the Element.
+    """
+
+    rough_string = ET.tostring(elem, 'utf-8')
+    reparsed = minidom.parseString(rough_string)
+    # Return the XML part, without the <?xml...> declaration
+    return reparsed.toprettyxml(indent="  ").splitlines(True)[1:]
+
+
+def generate_collaboration_xml(latex_file, output_filename, publication_reference, collab_name, collab_id):
+    """
+    Parses a revtex LaTeX file to generate INSPIRE-HEP compliant 
+    collaboration XML.
+    """
+
+    try:
+        with open(latex_file, 'r', encoding='utf-8') as f:
+            content = f.read()
+    except FileNotFoundError:
+        print(f"Error: The file '{latex_file}' was not found.")
+        sys.exit(1)
+
+    ET.register_namespace('foaf', "http://xmlns.com/foaf/0.1/")
+    ET.register_namespace('cal', "http://inspirehep.net/info/HepNames/tools/authors_xml/")
+
+    affiliation_pattern = re.compile(r'\\affiliation\{(.*?)\}')
+    
+    lines = content.splitlines()
+    authors_data = []
+    
+    unique_affiliations = OrderedDict()
+    for line in lines:
+        affil_match = affiliation_pattern.search(line)
+        if affil_match:
+            affiliation_text = affil_match.group(1).strip()
+            if affiliation_text not in unique_affiliations:
+                unique_affiliations[affiliation_text] = f"aff{len(unique_affiliations) + 1}"
+
+    # Second pass: associate authors with their affiliations
+    current_author_group = []
+    for i, line in enumerate(lines):
+        stripped_line = line.strip()
+        
+        # Parse author name
+        if stripped_line.startswith(r'\author{'):
+            start_index = line.find(r'\author{') + len(r'\author{')
+            brace_level = 1
+            end_index = -1
+            for j in range(start_index, len(line)):
+                if line[j] == '{':
+                    brace_level += 1
+                elif line[j] == '}':
+                    brace_level -= 1
+                    if brace_level == 0:
+                        end_index = j
+                        break
+            
+            if end_index == -1: continue # Skip malformed line
+
+            full_content = line[start_index:end_index]
+            
+            name = full_content.strip()
+            orcid = None
+            orcid_match = re.search(r'\\orcidlink\{(.*?)\}', full_content)
+            
+            if orcid_match:
+                orcid = orcid_match.group(1)
+                name = full_content[:orcid_match.start()].strip()
+                
+            author_info = {'name': name, 'orcid': orcid, 'affiliations': []}
+            authors_data.append(author_info)
+            current_author_group.append(author_info)
+
+        elif stripped_line.startswith(r'\affiliation{'):
+            affil_match = affiliation_pattern.search(line)
+            if not affil_match: continue
+
+            affiliation_text = affil_match.group(1).strip()
+            aff_id = unique_affiliations.get(affiliation_text)
+            if aff_id:
+                for author in current_author_group:
+                    if aff_id not in author['affiliations']:
+                        author['affiliations'].append(aff_id)
+            
+            next_line_is_affil = False
+            for j in range(i + 1, len(lines)):
+                future_line = lines[j].strip()
+                if not future_line: continue
+                if affiliation_pattern.search(future_line):
+                    next_line_is_affil = True
+                break
+            
+            if not next_line_is_affil:
+                 current_author_group = []
+
+    # --- Build the XML structure ---
+    ns = {'foaf': 'http://xmlns.com/foaf/0.1/', 'cal': 'http://inspirehep.net/info/HepNames/tools/authors_xml/'}
+    root = ET.Element('collaborationauthorlist')
+
+    ET.SubElement(root, f"{{{ns['cal']}}}creationDate").text = date.today().isoformat()
+    ET.SubElement(root, f"{{{ns['cal']}}}publicationReference").text = publication_reference
+    collaborations = ET.SubElement(root, f"{{{ns['cal']}}}collaborations")
+    collaboration = ET.SubElement(collaborations, f"{{{ns['cal']}}}collaboration", {'id': collab_id})
+    ET.SubElement(collaboration, f"{{{ns['foaf']}}}name").text = collab_name
+    organizations = ET.SubElement(root, f"{{{ns['cal']}}}organizations")
+    for text, org_id in unique_affiliations.items():
+        org = ET.SubElement(organizations, f"{{{ns['foaf']}}}Organization", {'id': org_id})
+        ET.SubElement(org, f"{{{ns['foaf']}}}name").text = text
+    authors_xml = ET.SubElement(root, f"{{{ns['cal']}}}authors")
+    for data in authors_data:
+        person = ET.SubElement(authors_xml, f"{{{ns['foaf']}}}Person")
+        ET.SubElement(person, f"{{{ns['cal']}}}authorNamePaper").text = data['name']
+        affs = ET.SubElement(person, f"{{{ns['cal']}}}authorAffiliations")
+        for aff_id in data['affiliations']:
+            ET.SubElement(affs, f"{{{ns['cal']}}}authorAffiliation", {'organizationid': aff_id, 'connection': ''})
+        if data['orcid']:
+            ids = ET.SubElement(person, f"{{{ns['cal']}}}authorids")
+            ET.SubElement(ids, f"{{{ns['cal']}}}authorid", {'source': 'ORCID'}).text = data['orcid']
+
+    xml_header = '<?xml version="1.0" encoding="UTF-8"?>\n'
+    doctype_header = '<!DOCTYPE collaborationauthorlist SYSTEM "author.dtd">\n\n'
+    xml_content_lines = pretty_print_xml(root)
+
+    with open(output_filename, 'w', encoding='utf-8') as f:
+        f.write(xml_header)
+        f.write(doctype_header)
+        f.writelines(xml_content_lines)
+
+    print(f"Successfully created '{output_filename}'!")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate INSPIRE-HEP compliant author XML from a revtex LaTeX file.")
+    
+    parser.add_argument("latex_file", help="Path to the input LaTeX file (.tex).")
+    parser.add_argument("-o", "--output", help="Path to the output XML file. Defaults to the input filename with a .xml extension.")
+    parser.add_argument("-r", "--ref", default="https://arxiv.org/abs/2503.14739", help="The publication reference URL (e.g., arXiv link).")
+    parser.add_argument("--collab-name", default="DESI", help="The name of the collaboration.")
+    parser.add_argument("--collab-id", default="c1", help="The ID for the collaboration (e.g., c1).")
+    
+    args = parser.parse_args()
+
+    if args.output:
+        output_filename = args.output
+    else:
+        base_name = os.path.splitext(args.latex_file)[0]
+        output_filename = f"{base_name}.xml"
+        
+    generate_collaboration_xml(
+        latex_file=args.latex_file,
+        output_filename=output_filename,
+        publication_reference=args.ref,
+        collab_name=args.collab_name,
+        collab_id=args.collab_id
+    )
+
+if __name__ == "__main__":
+    main()

--- a/mkauthlist/mkauthlist.py
+++ b/mkauthlist/mkauthlist.py
@@ -772,8 +772,10 @@ if __name__ == "__main__":
 
     output  = "%% Author list file generated with: %s %s \n"%(parser.prog, __version__ )
     output += "%% %s %s \n"%(os.path.basename(sys.argv[0]),' '.join(sys.argv[1:]))
-    output += "%% Orcid numbers may need \\usepackage{orcidlink}.\n"
-    output += "%% Use \\input to call the file\n\n"
+    if cls not in ['arxiv']: # non-TeX "journal(s)" for which the following lines are not relevant
+        if args.orcid: output += "%% Orcid numbers may need \\usepackage{orcidlink}.\n"
+        output += f"%% Use \\input{args.outfile if args.outfile is not None else '...'} to call the file\n"
+    output += "\n"
 
     if cls in ['jcap.appendix']: 
         if args.sort_firsttier: output += "\\emailAdd{firstauthor@email}\n\\affiliation{Affiliations are in Appendix \\ref{sec:affiliations}}\n"

--- a/mkauthlist/mkauthlist.py
+++ b/mkauthlist/mkauthlist.py
@@ -661,7 +661,7 @@ if __name__ == "__main__":
             authorkey = '{%s}'%(d['Authorname'])
 
             if args.orcid and d['ORCID']:
-                authorkey = authorkey + '\orcidlink{%s}'%d['ORCID'] 
+                authorkey = authorkey + '\\orcidlink{%s}'%d['ORCID'] 
 
             if (d['Affiliation'] not in affidict.keys()):
                 affidict[d['Affiliation']] = len(affidict.keys())
@@ -703,7 +703,7 @@ if __name__ == "__main__":
             authorkey = '{%s}'%(d['Authorname'])
 
             if args.orcid and d['ORCID']:
-                authorkey = authorkey + '\orcidlink{%s}'%d['ORCID'] 
+                authorkey = authorkey + '\\orcidlink{%s}'%d['ORCID'] 
 
             if (d['Affiliation'] not in affidict.keys()):
                 affidict[d['Affiliation']] = len(affidict.keys())
@@ -764,8 +764,8 @@ if __name__ == "__main__":
     output += "%% Use \\input to call the file\n\n"
 
     if cls in ['jcap.appendix']: 
-        if args.sort_firsttier: output += "\emailAdd{firsauthor@email}\n\\affiliation{Affiliations are in Appendix \\ref{sec:affiliations}}\n"
-        else: output += "\\author{{DESI Collaboration}:}\n\emailAdd{spokespersons@desi.lbl.gov}\n\\affiliation{Affiliations are in Appendix \\ref{sec:affiliations}}\n"
+        if args.sort_firsttier: output += "\\emailAdd{firsauthor@email}\n\\affiliation{Affiliations are in Appendix \\ref{sec:affiliations}}\n"
+        else: output += "\\author{{DESI Collaboration}:}\n\\emailAdd{spokespersons@desi.lbl.gov}\n\\affiliation{Affiliations are in Appendix \\ref{sec:affiliations}}\n"
 
 
     if args.doc:

--- a/mkauthlist/mkauthlist.py
+++ b/mkauthlist/mkauthlist.py
@@ -774,7 +774,7 @@ if __name__ == "__main__":
     output += "%% %s %s \n"%(os.path.basename(sys.argv[0]),' '.join(sys.argv[1:]))
     if cls not in ['arxiv']: # non-TeX "journal(s)" for which the following lines are not relevant
         if args.orcid: output += "%% Orcid numbers may need \\usepackage{orcidlink}.\n"
-        output += f"%% Use \\input{args.outfile if args.outfile is not None else '...'} to call the file\n"
+        output += "%% Use \\input{%s} to call the file\n"%(args.outfile if args.outfile is not None else '...')
     output += "\n"
 
     if cls in ['jcap.appendix']: 

--- a/mkauthlist/mkauthlist.py
+++ b/mkauthlist/mkauthlist.py
@@ -775,11 +775,9 @@ if __name__ == "__main__":
         output += authlist%params
         if cls in ['jcap.appendix']: 
             output2  = "%% Author list file generated with: %s %s \n"%(parser.prog, __version__ )
-            output2 += "%% Affiliations file. load \\usepackage{hanging}. Use \\input to call it after \\appendix\n\n\n"
-#            output2 += "\\section{Author Affiliations}\n\\label{sec:affiliations}\n\n\\begin{hangparas}{.5cm}{1}\n\n"
+            output2 += "%% Affiliations file. Use \\input to call it after \\appendix\n\n\n"
             output2 += "\\section{Author Affiliations}\n\\label{sec:affiliations}\n\n"
             output2 += affilist%params
-#            output2 += "\n\n\\end{hangparas}\n"
 
 
     if args.outfile is None:

--- a/mkauthlist/mkauthlist.py
+++ b/mkauthlist/mkauthlist.py
@@ -767,7 +767,7 @@ if __name__ == "__main__":
     output += "%% Use \\input to call the file\n\n"
 
     if cls in ['jcap.appendix']: 
-        if args.sort_firsttier: output += "\\emailAdd{firsauthor@email}\n\\affiliation{Affiliations are in Appendix \\ref{sec:affiliations}}\n"
+        if args.sort_firsttier: output += "\\emailAdd{firstauthor@email}\n\\affiliation{Affiliations are in Appendix \\ref{sec:affiliations}}\n"
         else: output += "\\author{{DESI Collaboration}:}\n\\emailAdd{spokespersons@desi.lbl.gov}\n\\affiliation{Affiliations are in Appendix \\ref{sec:affiliations}}\n"
 
 

--- a/mkauthlist/mkauthlist.py
+++ b/mkauthlist/mkauthlist.py
@@ -364,7 +364,7 @@ if __name__ == "__main__":
                         choices=sorted(journal2class.keys()),
                         help="journal name or latex document class.")
     parser.add_argument('--orcid', action='store_true',
-                        help="include ORCID information (elsevier, revtex and aastex).")
+                        help="include ORCID information (elsevier, revtex, aastex, mnras, emulateapj and aanda).")
     parser.add_argument('-s','--sort', action='store_true',
                         help="alphabetize the author list (you know you want to...).")
     parser.add_argument('-s1','--sort-firsttier', action='store_true',
@@ -567,7 +567,9 @@ if __name__ == "__main__":
             raise Exception(msg)
 
         for iauth, dat_auth in enumerate(data):
-            print(dat_auth['Authorname'])
+            authorkey = dat_auth['Authorname']
+            if args.orcid and dat_auth['ORCID']: authorkey += r'\orcidlink{%s}'%dat_auth['ORCID']
+            print(authorkey)
             if dat_auth['Affiliation'] == '':
                 logging.warning("Blank affiliation for '%s'"%dat_auth['Authorname'])
             if dat_auth['Authorname'] == '':
@@ -578,10 +580,10 @@ if __name__ == "__main__":
                 affidict[dat_auth['Affiliation']] = len(affidict.keys())
             affidx = affidict[dat_auth['Affiliation']]
 
-            if dat_auth['Authorname'] not in authdict.keys():
-                authdict[dat_auth['Authorname']] = [affidx]
+            if authorkey not in authdict.keys():
+                authdict[authorkey] = [affidx]
             else:
-                authdict[dat_auth['Authorname']].append(affidx)
+                authdict[authorkey].append(affidx)
 
         affiliations = []
         authors=[]
@@ -592,8 +594,6 @@ if __name__ == "__main__":
                 affmark = affmark.strip(',')
                 # Prefix 'and' on last entry (seems robust)
                 k = 'and ' + k
-            if args.orcid and data[i]['ORCID']:
-                k += '\\orcidlink{%s}'%data[i]['ORCID']
             author = k + affmark
             authors.append(author)
 

--- a/mkauthlist/mkauthlist.py
+++ b/mkauthlist/mkauthlist.py
@@ -692,7 +692,7 @@ if __name__ == "__main__":
         authlist = jcapappendix_authlist
         affilist = jcapappendix_affilist
         affilmark = r'%i,'
-        affiltext = r'$^{%i}${%s}'
+        affiltext = r'\noindent \hangindent=.5cm $^{%i}${%s}'
         for i,d in enumerate(data):
             if d['Affiliation'] == '':
                 logging.warn("Blank affiliation for '%s'"%d['Authorname'])
@@ -776,9 +776,10 @@ if __name__ == "__main__":
         if cls in ['jcap.appendix']: 
             output2  = "%% Author list file generated with: %s %s \n"%(parser.prog, __version__ )
             output2 += "%% Affiliations file. load \\usepackage{hanging}. Use \\input to call it after \\appendix\n\n\n"
-            output2 += "\\section{Author Affiliations}\n\\label{sec:affiliations}\n\n\\begin{hangparas}{.5cm}{1}\n\n"
+#            output2 += "\\section{Author Affiliations}\n\\label{sec:affiliations}\n\n\\begin{hangparas}{.5cm}{1}\n\n"
+            output2 += "\\section{Author Affiliations}\n\\label{sec:affiliations}\n\n"
             output2 += affilist%params
-            output2 += "\n\n\\end{hangparas}\n"
+#            output2 += "\n\n\\end{hangparas}\n"
 
 
     if args.outfile is None:

--- a/mkauthlist/mkauthlist.py
+++ b/mkauthlist/mkauthlist.py
@@ -350,7 +350,7 @@ if __name__ == "__main__":
     parser.add_argument('-a','--aux', metavar='order.csv',
                         help="auxiliary author ordering file (one name per line).")
     parser.add_argument('-c','--collab','--collaboration',
-                        default='DES Collaboration', help="collaboration name.")
+                        default='DESI Collaboration', help="collaboration name.")
     parser.add_argument('--cntrb','--contributions', nargs='?',
                         const='contributions.tex', help="contribution file.")
     parser.add_argument('-d','--doc', action='store_true',

--- a/mkauthlist/mkauthlist.py
+++ b/mkauthlist/mkauthlist.py
@@ -591,6 +591,8 @@ if __name__ == "__main__":
                 affmark = affmark.strip(',')
                 # Prefix 'and' on last entry (seems robust)
                 k = 'and ' + k
+            if args.orcid and data[i]['ORCID']:
+                k += '\\orcidlink{%s}'%data[i]['ORCID']
             author = k + affmark
             authors.append(author)
 

--- a/mkauthlist/mkauthlist.py
+++ b/mkauthlist/mkauthlist.py
@@ -343,9 +343,9 @@ if __name__ == "__main__":
     formatter = argparse.RawDescriptionHelpFormatter
     parser = argparse.ArgumentParser(description=description,
                                      formatter_class=formatter)
-    parser.add_argument('infile', metavar='DES-XXXX-XXXX_author_list.csv',
+    parser.add_argument('infile', metavar='DESI-XXXX-XXXX_author_list.csv',
                         help="input csv file from PubDB")
-    parser.add_argument('outfile', metavar='DES-XXXX-XXXX_author_list.tex',
+    parser.add_argument('outfile', metavar='DESI-XXXX-XXXX_author_list.tex',
                         nargs='?', default=None, help="output latex file (optional).")
     parser.add_argument('-a','--aux', metavar='order.csv',
                         help="auxiliary author ordering file (one name per line).")

--- a/mkauthlist/mkauthlist.py
+++ b/mkauthlist/mkauthlist.py
@@ -34,7 +34,6 @@ except:
 import os,sys
 import csv
 from collections import OrderedDict as odict
-import copy
 import re
 import logging
 

--- a/mkauthlist/mkauthlist.py
+++ b/mkauthlist/mkauthlist.py
@@ -78,9 +78,9 @@ def get_builders(data):
 def get_firsttier(data):
     """ Get a boolean array of the authors that are first tier. """
     if 'FirstTier' in data.dtype.names:
-        firsttiers = np.char.isdigit(data['FirstTier']) # basically strings that can be converted to numbers; empty strings can not and are excluded
+        firsttiers = np.char.isdigit(data['FirstTier']) # basically strings that can be converted to natural numbers (non-negative integers); empty strings can not and are excluded
         if np.any(np.char.str_len(data['FirstTier'][~firsttiers]) > 0):
-            logging.warning("Found strings in the FirstTier column that do not represent natural numbers, they will be ignored (affected authors will NOT be considered first-tier).")
+            logging.warning("Found strings in the FirstTier column that are not empty and do not represent natural numbers (non-negative integers), they will be ignored (affected authors will NOT be considered first-tier).")
         return firsttiers
     else:
         logging.warning("First-tier column (FirstTier) not found. Proceeding without first-tier authors.")

--- a/mkauthlist/mkauthlist.py
+++ b/mkauthlist/mkauthlist.py
@@ -60,7 +60,7 @@ def check_umlaut(lines):
         if umlaut.search(line) is None or quote.search(line) is None: continue
         if umlaut.search(line).start() > quote.search(line).start():
             msg =  "Found unescaped umlaut: " + line.strip()
-            logging.warn(msg)
+            logging.warning(msg)
     return lines
 
 def get_builders(data):
@@ -80,8 +80,7 @@ def get_firsttier(data):
     if 'FirstTier' in data.dtype.names:
         firsttiers = (np.char.lower(data['FirstTier']) != '')
     else:
-        msg = "No first tier column found."
-#        raise ValueError(msg)
+        logging.warning("No first tier column found.")
 
     return firsttiers
 
@@ -96,14 +95,14 @@ def write_contributions(filename,data):
     cntrbdict = odict()
     for i,d in enumerate(data):
         if cntrbdict.get(d['Authorname'],d['Contribution']) != d['Contribution']:
-            logging.warn("Non-unique contribution for '%(Authorname)s'"%d)
+            logging.warning("Non-unique contribution for '%(Authorname)s'"%d)
 
         cntrbdict[d['Authorname']]=d['Contribution']
 
     output = r'Author contributions are listed below. \\'+'\n'
     for i,(name,cntrb) in enumerate(cntrbdict.items()):
         if cntrb == '':
-            logging.warn("Blank contribution for '%s'"%name)
+            logging.warning("Blank contribution for '%s'"%name)
 
         output += r'%s: %s \\'%(name,cntrb) + '\n'
 
@@ -441,7 +440,7 @@ if __name__ == "__main__":
 
     # Hack for umlauts in affiliations...
     for k, v in HACK.items():
-        logging.warn("Hacking '%s' ..."%k)
+        logging.warning("Hacking '%s' ..."%k)
         select = (np.char.count(data['Affiliation'],k) > 0)
         data['Affiliation'][select] = v
 
@@ -480,7 +479,7 @@ if __name__ == "__main__":
             if np.sum(match) < 1:
                 msg = "Auxiliary name not found: %s"%(lastname)
                 if firstname: msg += ', %s'%firstname
-                logging.warn(msg)
+                logging.warning(msg)
                 continue
 
             # Check unique firstname
@@ -509,10 +508,10 @@ if __name__ == "__main__":
 
         for i,d in enumerate(data):
             if d['Affiliation'] == '':
-                logging.warn("Blank affiliation for '%s'"%d['Authorname'])
+                logging.warning("Blank affiliation for '%s'"%d['Authorname'])
             if d['Authorname'] == '':
-                logging.warn("Blank authorname for '%s %s'"%(d['Firstname'],
-                                                             d['Lastname']))
+                logging.warning("Blank authorname for '%s %s'"%(d['Firstname'],
+                                                                d['Lastname']))
 
             authorkey = '{%s}'%(d['Authorname'])
 
@@ -567,10 +566,10 @@ if __name__ == "__main__":
         for iauth, dat_auth in enumerate(data):
             print(dat_auth['Authorname'])
             if dat_auth['Affiliation'] == '':
-                logging.warn("Blank affiliation for '%s'"%dat_auth['Authorname'])
+                logging.warning("Blank affiliation for '%s'"%dat_auth['Authorname'])
             if dat_auth['Authorname'] == '':
-                logging.warn("Blank authorname for '%s %s'"%(dat_auth['Firstname'],
-                                                             dat_auth['Lastname']))
+                logging.warning("Blank authorname for '%s %s'"%(dat_auth['Firstname'],
+                                                                dat_auth['Lastname']))
 
             if (dat_auth['Affiliation'] not in affidict.keys()):
                 affidict[dat_auth['Affiliation']] = len(affidict.keys())
@@ -619,10 +618,10 @@ if __name__ == "__main__":
         affiltext = r'\address[%i]{%s}'
         for i,d in enumerate(data):
             if d['Affiliation'] == '':
-                logging.warn("Blank affiliation for '%s'"%d['Authorname'])
+                logging.warning("Blank affiliation for '%s'"%d['Authorname'])
             if d['Authorname'] == '':
-                logging.warn("Blank authorname for '%s %s'"%(d['Firstname'],
-                                                             d['Lastname']))
+                logging.warning("Blank authorname for '%s %s'"%(d['Firstname'],
+                                                                d['Lastname']))
 
             if (d['Affiliation'] not in affidict.keys()):
                 affidict[d['Affiliation']] = len(affidict.keys())
@@ -654,10 +653,10 @@ if __name__ == "__main__":
         affiltext = r'\affiliation[%i]{%s}'
         for i,d in enumerate(data):
             if d['Affiliation'] == '':
-                logging.warn("Blank affiliation for '%s'"%d['Authorname'])
+                logging.warning("Blank affiliation for '%s'"%d['Authorname'])
             if d['Authorname'] == '':
-                logging.warn("Blank authorname for '%s %s'"%(d['Firstname'],
-                                                             d['Lastname']))
+                logging.warning("Blank authorname for '%s %s'"%(d['Firstname'],
+                                                                d['Lastname']))
 
             authorkey = '{%s}'%(d['Authorname'])
 
@@ -696,10 +695,10 @@ if __name__ == "__main__":
         affiltext = r'\noindent \hangindent=.5cm $^{%i}${%s}'
         for i,d in enumerate(data):
             if d['Affiliation'] == '':
-                logging.warn("Blank affiliation for '%s'"%d['Authorname'])
+                logging.warning("Blank affiliation for '%s'"%d['Authorname'])
             if d['Authorname'] == '':
-                logging.warn("Blank authorname for '%s %s'"%(d['Firstname'],
-                                                             d['Lastname']))
+                logging.warning("Blank authorname for '%s %s'"%(d['Firstname'],
+                                                                d['Lastname']))
 
             authorkey = '{%s}'%(d['Authorname'])
 
@@ -741,8 +740,8 @@ if __name__ == "__main__":
 
         for i,d in enumerate(data):
             if d['Authorname'] == '':
-                logging.warn("Blank authorname for '%s %s'"%(d['Firstname'],
-                                                             d['Lastname']))
+                logging.warning("Blank authorname for '%s %s'"%(d['Firstname'],
+                                                                d['Lastname']))
             if (d['Affiliation'] not in affidict.keys()):
                 affidict[d['Affiliation']] = len(affidict.keys())
             affidx = affidict[d['Affiliation']]
@@ -786,7 +785,7 @@ if __name__ == "__main__":
     else:
         outfile = args.outfile
         if os.path.exists(outfile) and not args.force:
-            logging.warn("Found %s; skipping..."%outfile)
+            logging.warning("Found %s; skipping..."%outfile)
         out = open(outfile,'w')
         out.write(output)
         out.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "versioneer"]
+build-backend = "setuptools.build_meta"

--- a/versioneer.py
+++ b/versioneer.py
@@ -409,9 +409,8 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
-    with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+    parser = configparser.ConfigParser()
+    parser.read(setup_cfg)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
I created the new mkauthorxml.py script to create the author.xml file required by PRD. (It was developed for the DR2 LyA BAO KP). It should be useful for other collaboration papers that go to APS journals.

Basic usage is 
`python mkauthorxml.py manuscript.tex --ref arxiv --collab-name DESI`

The default output is manuscript.xml, and was accepted by APS for the paper. See the script for more details.